### PR TITLE
活動報告のfrontmatterを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Engine ホームページ
 
 URL: https://ycu-engine.github.io/
+
+# MDX
+
+- Dateの部分はUTCで解釈され、UTCのTZ付きの文字列として返される。なので`Date型`に変換する際は注意が必要
+
+    ```javascript
+    // result.date <- 2021-02-08T00:00:00.000Z
+    const date = new Date(result.date)
+
+    // date <- Mon Feb 08 2021 09:00:00 GMT+0900 (日本標準時)
+
+    ```

--- a/graphql-types.ts
+++ b/graphql-types.ts
@@ -28,6 +28,8 @@ export type Scalars = {
 
 
 
+
+
 export type AvifOptions = {
   quality?: Maybe<Scalars['Int']>;
   lossless?: Maybe<Scalars['Boolean']>;
@@ -1447,11 +1449,12 @@ export type FileFieldsEnum =
   | 'childrenMdx___frontmatter___participants___joinedAt'
   | 'childrenMdx___frontmatter___participants___id'
   | 'childrenMdx___frontmatter___participants___children'
-  | 'childrenMdx___frontmatter___date'
+  | 'childrenMdx___frontmatter___duration'
   | 'childrenMdx___frontmatter___startTime'
   | 'childrenMdx___frontmatter___endTime'
-  | 'childrenMdx___frontmatter___topics'
+  | 'childrenMdx___frontmatter___date'
   | 'childrenMdx___frontmatter___teamName'
+  | 'childrenMdx___frontmatter___topics'
   | 'childrenMdx___slug'
   | 'childrenMdx___body'
   | 'childrenMdx___excerpt'
@@ -1522,11 +1525,12 @@ export type FileFieldsEnum =
   | 'childMdx___frontmatter___participants___joinedAt'
   | 'childMdx___frontmatter___participants___id'
   | 'childMdx___frontmatter___participants___children'
-  | 'childMdx___frontmatter___date'
+  | 'childMdx___frontmatter___duration'
   | 'childMdx___frontmatter___startTime'
   | 'childMdx___frontmatter___endTime'
-  | 'childMdx___frontmatter___topics'
+  | 'childMdx___frontmatter___date'
   | 'childMdx___frontmatter___teamName'
+  | 'childMdx___frontmatter___topics'
   | 'childMdx___slug'
   | 'childMdx___body'
   | 'childMdx___excerpt'
@@ -2460,11 +2464,12 @@ export type MdxFieldsEnum =
   | 'frontmatter___participants___internal___mediaType'
   | 'frontmatter___participants___internal___owner'
   | 'frontmatter___participants___internal___type'
-  | 'frontmatter___date'
+  | 'frontmatter___duration'
   | 'frontmatter___startTime'
   | 'frontmatter___endTime'
-  | 'frontmatter___topics'
+  | 'frontmatter___date'
   | 'frontmatter___teamName'
+  | 'frontmatter___topics'
   | 'slug'
   | 'body'
   | 'excerpt'
@@ -2592,11 +2597,22 @@ export type MdxFrontmatter = {
   title: Scalars['String'];
   team?: Maybe<Team>;
   participants?: Maybe<Array<Maybe<Member>>>;
+  duration?: Maybe<Scalars['Int']>;
+  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']>;
   date?: Maybe<Scalars['Date']>;
-  startTime?: Maybe<Scalars['Int']>;
-  endTime?: Maybe<Scalars['Int']>;
-  topics?: Maybe<Array<Maybe<Scalars['String']>>>;
   teamName?: Maybe<Scalars['String']>;
+  topics?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+
+export type MdxFrontmatterStartTimeArgs = {
+  format?: Scalars['String'];
+};
+
+
+export type MdxFrontmatterEndTimeArgs = {
+  format?: Scalars['String'];
 };
 
 
@@ -2611,11 +2627,12 @@ export type MdxFrontmatterFilterInput = {
   title?: Maybe<StringQueryOperatorInput>;
   team?: Maybe<TeamFilterInput>;
   participants?: Maybe<MemberFilterListInput>;
+  duration?: Maybe<IntQueryOperatorInput>;
+  startTime?: Maybe<StringQueryOperatorInput>;
+  endTime?: Maybe<StringQueryOperatorInput>;
   date?: Maybe<DateQueryOperatorInput>;
-  startTime?: Maybe<IntQueryOperatorInput>;
-  endTime?: Maybe<IntQueryOperatorInput>;
-  topics?: Maybe<StringQueryOperatorInput>;
   teamName?: Maybe<StringQueryOperatorInput>;
+  topics?: Maybe<StringQueryOperatorInput>;
 };
 
 export type MdxGroupConnection = {
@@ -4132,15 +4149,15 @@ export type QuerySitePageArgs = {
   internalComponentName?: Maybe<StringQueryOperatorInput>;
   componentChunkName?: Maybe<StringQueryOperatorInput>;
   matchPath?: Maybe<StringQueryOperatorInput>;
+  id?: Maybe<StringQueryOperatorInput>;
+  parent?: Maybe<NodeFilterInput>;
+  children?: Maybe<NodeFilterListInput>;
+  internal?: Maybe<InternalFilterInput>;
   isCreatedByStatefulCreatePages?: Maybe<BooleanQueryOperatorInput>;
   context?: Maybe<SitePageContextFilterInput>;
   pluginCreator?: Maybe<SitePluginFilterInput>;
   pluginCreatorId?: Maybe<StringQueryOperatorInput>;
   componentPath?: Maybe<StringQueryOperatorInput>;
-  id?: Maybe<StringQueryOperatorInput>;
-  parent?: Maybe<NodeFilterInput>;
-  children?: Maybe<NodeFilterListInput>;
-  internal?: Maybe<InternalFilterInput>;
 };
 
 
@@ -4759,15 +4776,15 @@ export type SitePage = Node & {
   internalComponentName: Scalars['String'];
   componentChunkName: Scalars['String'];
   matchPath?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  parent?: Maybe<Node>;
+  children: Array<Node>;
+  internal: Internal;
   isCreatedByStatefulCreatePages?: Maybe<Scalars['Boolean']>;
   context?: Maybe<SitePageContext>;
   pluginCreator?: Maybe<SitePlugin>;
   pluginCreatorId?: Maybe<Scalars['String']>;
   componentPath?: Maybe<Scalars['String']>;
-  id: Scalars['ID'];
-  parent?: Maybe<Node>;
-  children: Array<Node>;
-  internal: Internal;
 };
 
 export type SitePageConnection = {
@@ -4811,85 +4828,6 @@ export type SitePageFieldsEnum =
   | 'internalComponentName'
   | 'componentChunkName'
   | 'matchPath'
-  | 'isCreatedByStatefulCreatePages'
-  | 'context___slug'
-  | 'pluginCreator___id'
-  | 'pluginCreator___parent___id'
-  | 'pluginCreator___parent___parent___id'
-  | 'pluginCreator___parent___parent___children'
-  | 'pluginCreator___parent___children'
-  | 'pluginCreator___parent___children___id'
-  | 'pluginCreator___parent___children___children'
-  | 'pluginCreator___parent___internal___content'
-  | 'pluginCreator___parent___internal___contentDigest'
-  | 'pluginCreator___parent___internal___description'
-  | 'pluginCreator___parent___internal___fieldOwners'
-  | 'pluginCreator___parent___internal___ignoreType'
-  | 'pluginCreator___parent___internal___mediaType'
-  | 'pluginCreator___parent___internal___owner'
-  | 'pluginCreator___parent___internal___type'
-  | 'pluginCreator___children'
-  | 'pluginCreator___children___id'
-  | 'pluginCreator___children___parent___id'
-  | 'pluginCreator___children___parent___children'
-  | 'pluginCreator___children___children'
-  | 'pluginCreator___children___children___id'
-  | 'pluginCreator___children___children___children'
-  | 'pluginCreator___children___internal___content'
-  | 'pluginCreator___children___internal___contentDigest'
-  | 'pluginCreator___children___internal___description'
-  | 'pluginCreator___children___internal___fieldOwners'
-  | 'pluginCreator___children___internal___ignoreType'
-  | 'pluginCreator___children___internal___mediaType'
-  | 'pluginCreator___children___internal___owner'
-  | 'pluginCreator___children___internal___type'
-  | 'pluginCreator___internal___content'
-  | 'pluginCreator___internal___contentDigest'
-  | 'pluginCreator___internal___description'
-  | 'pluginCreator___internal___fieldOwners'
-  | 'pluginCreator___internal___ignoreType'
-  | 'pluginCreator___internal___mediaType'
-  | 'pluginCreator___internal___owner'
-  | 'pluginCreator___internal___type'
-  | 'pluginCreator___resolve'
-  | 'pluginCreator___name'
-  | 'pluginCreator___version'
-  | 'pluginCreator___pluginOptions___alias____'
-  | 'pluginCreator___pluginOptions___extensions'
-  | 'pluginCreator___pluginOptions___isTSX'
-  | 'pluginCreator___pluginOptions___jsxPragma'
-  | 'pluginCreator___pluginOptions___allExtensions'
-  | 'pluginCreator___pluginOptions___name'
-  | 'pluginCreator___pluginOptions___path'
-  | 'pluginCreator___pluginOptions___lessBabel'
-  | 'pluginCreator___pluginOptions___mediaTypes'
-  | 'pluginCreator___pluginOptions___base64Width'
-  | 'pluginCreator___pluginOptions___stripMetadata'
-  | 'pluginCreator___pluginOptions___defaultQuality'
-  | 'pluginCreator___pluginOptions___failOnError'
-  | 'pluginCreator___pluginOptions___pathCheck'
-  | 'pluginCreator___nodeAPIs'
-  | 'pluginCreator___browserAPIs'
-  | 'pluginCreator___ssrAPIs'
-  | 'pluginCreator___pluginFilepath'
-  | 'pluginCreator___packageJson___name'
-  | 'pluginCreator___packageJson___description'
-  | 'pluginCreator___packageJson___version'
-  | 'pluginCreator___packageJson___main'
-  | 'pluginCreator___packageJson___author'
-  | 'pluginCreator___packageJson___license'
-  | 'pluginCreator___packageJson___dependencies'
-  | 'pluginCreator___packageJson___dependencies___name'
-  | 'pluginCreator___packageJson___dependencies___version'
-  | 'pluginCreator___packageJson___devDependencies'
-  | 'pluginCreator___packageJson___devDependencies___name'
-  | 'pluginCreator___packageJson___devDependencies___version'
-  | 'pluginCreator___packageJson___peerDependencies'
-  | 'pluginCreator___packageJson___peerDependencies___name'
-  | 'pluginCreator___packageJson___peerDependencies___version'
-  | 'pluginCreator___packageJson___keywords'
-  | 'pluginCreatorId'
-  | 'componentPath'
   | 'id'
   | 'parent___id'
   | 'parent___parent___id'
@@ -4975,7 +4913,86 @@ export type SitePageFieldsEnum =
   | 'internal___ignoreType'
   | 'internal___mediaType'
   | 'internal___owner'
-  | 'internal___type';
+  | 'internal___type'
+  | 'isCreatedByStatefulCreatePages'
+  | 'context___slug'
+  | 'pluginCreator___id'
+  | 'pluginCreator___parent___id'
+  | 'pluginCreator___parent___parent___id'
+  | 'pluginCreator___parent___parent___children'
+  | 'pluginCreator___parent___children'
+  | 'pluginCreator___parent___children___id'
+  | 'pluginCreator___parent___children___children'
+  | 'pluginCreator___parent___internal___content'
+  | 'pluginCreator___parent___internal___contentDigest'
+  | 'pluginCreator___parent___internal___description'
+  | 'pluginCreator___parent___internal___fieldOwners'
+  | 'pluginCreator___parent___internal___ignoreType'
+  | 'pluginCreator___parent___internal___mediaType'
+  | 'pluginCreator___parent___internal___owner'
+  | 'pluginCreator___parent___internal___type'
+  | 'pluginCreator___children'
+  | 'pluginCreator___children___id'
+  | 'pluginCreator___children___parent___id'
+  | 'pluginCreator___children___parent___children'
+  | 'pluginCreator___children___children'
+  | 'pluginCreator___children___children___id'
+  | 'pluginCreator___children___children___children'
+  | 'pluginCreator___children___internal___content'
+  | 'pluginCreator___children___internal___contentDigest'
+  | 'pluginCreator___children___internal___description'
+  | 'pluginCreator___children___internal___fieldOwners'
+  | 'pluginCreator___children___internal___ignoreType'
+  | 'pluginCreator___children___internal___mediaType'
+  | 'pluginCreator___children___internal___owner'
+  | 'pluginCreator___children___internal___type'
+  | 'pluginCreator___internal___content'
+  | 'pluginCreator___internal___contentDigest'
+  | 'pluginCreator___internal___description'
+  | 'pluginCreator___internal___fieldOwners'
+  | 'pluginCreator___internal___ignoreType'
+  | 'pluginCreator___internal___mediaType'
+  | 'pluginCreator___internal___owner'
+  | 'pluginCreator___internal___type'
+  | 'pluginCreator___resolve'
+  | 'pluginCreator___name'
+  | 'pluginCreator___version'
+  | 'pluginCreator___pluginOptions___alias____'
+  | 'pluginCreator___pluginOptions___extensions'
+  | 'pluginCreator___pluginOptions___isTSX'
+  | 'pluginCreator___pluginOptions___jsxPragma'
+  | 'pluginCreator___pluginOptions___allExtensions'
+  | 'pluginCreator___pluginOptions___name'
+  | 'pluginCreator___pluginOptions___path'
+  | 'pluginCreator___pluginOptions___lessBabel'
+  | 'pluginCreator___pluginOptions___mediaTypes'
+  | 'pluginCreator___pluginOptions___base64Width'
+  | 'pluginCreator___pluginOptions___stripMetadata'
+  | 'pluginCreator___pluginOptions___defaultQuality'
+  | 'pluginCreator___pluginOptions___failOnError'
+  | 'pluginCreator___pluginOptions___pathCheck'
+  | 'pluginCreator___nodeAPIs'
+  | 'pluginCreator___browserAPIs'
+  | 'pluginCreator___ssrAPIs'
+  | 'pluginCreator___pluginFilepath'
+  | 'pluginCreator___packageJson___name'
+  | 'pluginCreator___packageJson___description'
+  | 'pluginCreator___packageJson___version'
+  | 'pluginCreator___packageJson___main'
+  | 'pluginCreator___packageJson___author'
+  | 'pluginCreator___packageJson___license'
+  | 'pluginCreator___packageJson___dependencies'
+  | 'pluginCreator___packageJson___dependencies___name'
+  | 'pluginCreator___packageJson___dependencies___version'
+  | 'pluginCreator___packageJson___devDependencies'
+  | 'pluginCreator___packageJson___devDependencies___name'
+  | 'pluginCreator___packageJson___devDependencies___version'
+  | 'pluginCreator___packageJson___peerDependencies'
+  | 'pluginCreator___packageJson___peerDependencies___name'
+  | 'pluginCreator___packageJson___peerDependencies___version'
+  | 'pluginCreator___packageJson___keywords'
+  | 'pluginCreatorId'
+  | 'componentPath';
 
 export type SitePageFilterInput = {
   path?: Maybe<StringQueryOperatorInput>;
@@ -4983,15 +5000,15 @@ export type SitePageFilterInput = {
   internalComponentName?: Maybe<StringQueryOperatorInput>;
   componentChunkName?: Maybe<StringQueryOperatorInput>;
   matchPath?: Maybe<StringQueryOperatorInput>;
+  id?: Maybe<StringQueryOperatorInput>;
+  parent?: Maybe<NodeFilterInput>;
+  children?: Maybe<NodeFilterListInput>;
+  internal?: Maybe<InternalFilterInput>;
   isCreatedByStatefulCreatePages?: Maybe<BooleanQueryOperatorInput>;
   context?: Maybe<SitePageContextFilterInput>;
   pluginCreator?: Maybe<SitePluginFilterInput>;
   pluginCreatorId?: Maybe<StringQueryOperatorInput>;
   componentPath?: Maybe<StringQueryOperatorInput>;
-  id?: Maybe<StringQueryOperatorInput>;
-  parent?: Maybe<NodeFilterInput>;
-  children?: Maybe<NodeFilterListInput>;
-  internal?: Maybe<InternalFilterInput>;
 };
 
 export type SitePageGroupConnection = {

--- a/src/data/activity_log/20210112_general.mdx
+++ b/src/data/activity_log/20210112_general.mdx
@@ -1,6 +1,6 @@
 ---
 title: 第0回 Engine会議録
-date: 2021-01-12
+date: '2021-01-12'
 startTime: 19:00
 endTime: 21:00
 participants:

--- a/src/data/activity_log/20210115_data_analitics.mdx
+++ b/src/data/activity_log/20210115_data_analitics.mdx
@@ -1,6 +1,6 @@
 ---
 title: 第1回 データ分析MTG
-date: 2021-01-15
+date: '2021-01-15'
 startTime: 17:00
 endTime: 18:30
 teamName: DataAnalitics

--- a/src/data/activity_log/20210122_data_analitics.mdx
+++ b/src/data/activity_log/20210122_data_analitics.mdx
@@ -1,6 +1,6 @@
 ---
 title: 第2回 データ分析MTG
-date: 2021-01-22
+date: '2021-01-22'
 startTime: 17:00
 endTime: 18:55
 teamName: DataAnalitics

--- a/src/data/activity_log/20210128_general_1.mdx
+++ b/src/data/activity_log/20210128_general_1.mdx
@@ -1,6 +1,6 @@
 ---
 title: 第1回 オリエンテーション
-date: 2021-01-28
+date: '2021-01-28'
 startTime: 13:00
 endTime: 14:30
 participants:

--- a/src/data/activity_log/20210128_general_2.mdx
+++ b/src/data/activity_log/20210128_general_2.mdx
@@ -1,6 +1,6 @@
 ---
 title: 第2回 オリエンテーション
-date: 2021-01-28
+date: '2021-01-28'
 startTime: 19:00
 endTime: 21:00
 participants:

--- a/src/data/activity_log/20210129_beginner.mdx
+++ b/src/data/activity_log/20210129_beginner.mdx
@@ -1,6 +1,6 @@
 ---
 title: 第3回 オリエンテーション
-date: 2021-01-29
+date: '2021-01-29'
 startTime: 10:00
 endTime: 12:20
 team: Beginner

--- a/src/data/activity_log/20210129_data_analitics.mdx
+++ b/src/data/activity_log/20210129_data_analitics.mdx
@@ -1,6 +1,6 @@
 ---
 title: 第3回 データ分析MTG
-date: 2021-01-29
+date: '2021-01-29'
 startTime: 17:00
 endTime: 18:00
 teamName: DataAnalitics

--- a/src/data/activity_log/20210129_web.mdx
+++ b/src/data/activity_log/20210129_web.mdx
@@ -1,6 +1,6 @@
 ---
 title: YCUスケジュールの運用について
-date: 2021-01-29
+date: '2021-01-29'
 startTime: 14:00
 endTime: 14:24
 team: Web

--- a/src/data/activity_log/20210205_data_analitics.mdx
+++ b/src/data/activity_log/20210205_data_analitics.mdx
@@ -1,6 +1,6 @@
 ---
 title: 第4回 データ分析MTG
-date: 2021-02-05
+date: '2021-02-05'
 startTime: 17:00
 endTime: 19:00
 teamName: DataAnalitics

--- a/src/data/activity_log/20210208_beginner.mdx
+++ b/src/data/activity_log/20210208_beginner.mdx
@@ -1,6 +1,6 @@
 ---
 title: 第1回 ビギナーチーム会
-date: 2021-02-08
+date: '2021-02-08'
 startTime: 10:00
 endTime: 10:40
 team: Beginner

--- a/src/pages/activity_log.tsx
+++ b/src/pages/activity_log.tsx
@@ -29,8 +29,8 @@ export const pageQuery = graphql`
           frontmatter {
             date
             title
-            startTime
-            endTime
+            startTime(format: "hh時mm分")
+            endTime(format: "hh時mm分")
           }
         }
       }
@@ -57,8 +57,9 @@ const ActivityLogPage = ({ data }: ActivityLogPageProps): JSX.Element => {
                 {file.childMdx?.frontmatter?.title}
               </h2>
               <h3 className="text-lg mb-2">
-                {file.childMdx?.frontmatter?.date}{' '}
-                {file.childMdx?.frontmatter?.startTime}
+                {file.childMdx?.frontmatter?.date}(
+                {file.childMdx?.frontmatter?.startTime}~
+                {file.childMdx?.frontmatter?.endTime})
               </h3>
               {file.childMdx?.body ? (
                 <MDXRenderer>{file.childMdx.body}</MDXRenderer>


### PR DESCRIPTION
startTimeとendTimeにフォーマットを指定できるようにした

# 変更内容チェック

- [ ] データの変更
    - [ ] ユーザーの追加・修正
    - [ ] スキルの追加・修正
    - [ ] 学部等の追加・修正
    - [ ] チームの追加・修正
    - [ ] ポートフォリオの追加・修正
    - [ ] 活動記録の追加・修正
- [ ] ページの変更
    - [ ] 新しいページを追加
    - [x] 既存のページを修正
    
