### PR TITLE
独自eslintルールでエラーでないようにする

### DIFF
--- a/eslint/mdx/rule/mdx-components.js
+++ b/eslint/mdx/rule/mdx-components.js
@@ -15,7 +15,6 @@ const getLineColumn = require('../helper/get-line-column').getLineColumn
 module.exports = {
   meta: {},
   create(context) {
-    const filename = context.getFilename()
     const sourceCode = context.getSourceCode()
     const sourceText = sourceCode.getText()
 

--- a/eslint/mdx/rule/mdx-frontmatter-team.js
+++ b/eslint/mdx/rule/mdx-frontmatter-team.js
@@ -22,7 +22,24 @@ module.exports = {
     if (!isActivityLog) return {}
 
     const sourceCodeText = sourceCode.text
-    const frontmatter = matter(sourceCodeText)
+    /** @type {matter.GrayMatterFile<string>} */
+    let frontmatter
+    try {
+      frontmatter = matter(sourceCodeText)
+    } catch {
+      frontmatter = undefined
+    }
+    if (!frontmatter) {
+      return {
+        Program: (node) => {
+          context.report({
+            node,
+            message:
+              'ファイルのメタ情報(frontmatter)部分に構文エラーがあります',
+          })
+        },
+      }
+    }
     return {
       Program: (node) => {
         if (!frontmatter.data.team) return


### PR DESCRIPTION
# 変更内容チェック

- [ ] データの変更
    - [ ] ユーザーの追加・修正
    - [ ] スキルの追加・修正
    - [ ] 学部等の追加・修正
    - [ ] チームの追加・修正
    - [ ] ポートフォリオの追加・修正
    - [ ] 活動記録の追加・修正
- [ ] ページの変更
    - [ ] 新しいページを追加
    - [ ] 既存のページを修正
    
