### PR TITLE
2021年3月21日 ビギナーチーム活動報告

### DIFF
--- a/src/data/activity_log/20210321_beginner.mdx
+++ b/src/data/activity_log/20210321_beginner.mdx
@@ -1,0 +1,35 @@
+---
+title: 第7回 ビギナーチーム会
+date: '2021-03-21'
+startTime: 22:00
+endTime: 23:00
+teamName: Beginner
+participants:
+  - KakeruSato
+  - KentaroMorota
+  - YutaUra
+  - TsuyoshiMatsumaru
+  - FujiharuKawahara
+topics:
+  - 勉強報告
+---
+
+# やったこと
+
+## 今週勉強したことについて報告
+
+### <user name="KentaroMorota" />
+
+[udemy の講座をやりました](https://github.com/ycu-engine/community/issues/34)
+
+### <user name="FujiharuKawahara" />
+
+[環境構築やってる途中です。](https://github.com/ycu-engine/community/issues/35)
+
+### <user name="KakeruSato" />
+
+[ボストン住宅価格データセットを使って MLP の使い方を学びました](https://github.com/ycu-engine/community/issues/36)
+
+### <user name="TsuyoshiMatsumaru" />
+
+バックグラウンドや Flutter を触るきっかけなどを話してもらいました。


### PR DESCRIPTION
# 変更内容チェック

- [ ] データの変更
  - [ ] ユーザーの追加・修正
  - [ ] スキルの追加・修正
  - [ ] 学部等の追加・修正
  - [ ] チームの追加・修正
  - [ ] ポートフォリオの追加・修正
  - [x] 活動記録の追加・修正
  - [ ] イベントの追加・修正
- [ ] ページの変更
  - [ ] 新しいページを追加
  - [ ] 既存のページを修正
