### PR TITLE
2021年3月29日 データ分析チーム活動報告

### DIFF
--- a/src/data/activity_log/20210329_data_analitics.mdx
+++ b/src/data/activity_log/20210329_data_analitics.mdx
@@ -1,0 +1,36 @@
+---
+title: 第11回 データ分析MTG
+date: '2021-03-29'
+startTime: 11:00
+endTime: 12:30
+teamName: DataAnalitics
+participants:
+  - YutaUra
+  - YoshiyukiKobayashi
+  - YosukeMuroi
+topics:
+  - Kaggle
+  - 自然言語処理
+---
+
+# やったこと
+
+## <user name="YoshiyukiKobayashi" />
+
+自然言語処理のツールの一部である`Stemmers`というモジュールを使用してロジスティック回帰分析で分析・予測を行った。
+BERT で深層学習するのと同じくらいのスコアがでた
+
+## <user name="YosukeMuroi"/>
+
+深層学習のパラメータチューニングをしつつ、学習を行ったが、Colab 上ではエラーが発生してうまく動作しない箇所もあった。
+
+## <user name="YutaUra" />
+
+BERT と PyTorch を使って深層学習で学習・予測を行った。
+
+# 次回までやること
+
+次回は 4 月５日の午前中
+それ以降月曜４限の時間で活動する予定
+
+次回からは[Coleridge Initiative - Show US the Data](https://www.kaggle.com/c/coleridgeinitiative-show-us-the-data/overview)を行う


### PR DESCRIPTION
# 変更内容チェック

- [ ] データの変更
  - [ ] ユーザーの追加・修正
  - [ ] スキルの追加・修正
  - [ ] 学部等の追加・修正
  - [ ] チームの追加・修正
  - [ ] ポートフォリオの追加・修正
  - [x] 活動記録の追加・修正
  - [ ] イベントの追加・修正
- [ ] ページの変更
  - [ ] 新しいページを追加
  - [ ] 既存のページを修正
